### PR TITLE
Preserve symbolic links when copying files via cp.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ rm -rf $build_dir && mkdir -p $build_dir
 
 for f in *prerun.sh home
 do
-    cp -r $CDIR/$f $build_dir/
+    cp -R $CDIR/$f $build_dir/
 done
 
 if [ -x "$(command -v pip)" ]; then


### PR DESCRIPTION
On GNU/Linux cp -r and cp -R behind identically, and symbolic links are preserved.

However, on macOS they behave differently: cp -r will copy the indirected symbolic link (i.e the content is copied, resulting in a regular file).

This patch changes all occurrences of cp -r with cp -R.

Tested on:

macOS 12.6 (Monterey)
Ubuntu 18.04 LTS
Ubuntu 22.04 LTS